### PR TITLE
ci(release): publish multi-arch image (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             GITHUB_TOKEN=${{ secrets.PAT_DISPATCH }}


### PR DESCRIPTION
## Summary

Adds `linux/arm64` to the published image so the WebApp image ships a **multi-arch manifest** instead of amd64-only — same change as PayrollEngine.Backend#18.

## The change (one line)

```diff
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
```

## Why no QEMU is needed

The `Dockerfile` already supports arm64: the build stage is pinned to `--platform=$BUILDPLATFORM` (runs natively on the runner and cross-compiles), branches on `$TARGETARCH` to publish with `--runtime linux-arm64` / `linux-x64`, and the final stage has **no `RUN`** (only `COPY` + `ENTRYPOINT`). So buildx cross-builds the arm64 image from the amd64 runner without emulation. The `gha` cache still works per-platform.

## Verified locally

Ran the exact buildx invocation the workflow uses, for both platforms, with `NUGET_SOURCE=nuget.org` (as an external consumer, no GitHub Packages token):

```bash
docker buildx build --platform linux/amd64,linux/arm64 \
  --build-arg NUGET_SOURCE=nuget.org \
  --output type=oci,dest=out.tar .
```

Result — a proper multi-arch manifest list (`linux/amd64` + `linux/arm64`), **no QEMU** (`qemu` / `exec format error` absent from the build log), exit code 0. Build-stage steps logged as `[linux/arm64->amd64 build ...]` (cross-compiled) — no step ran under emulation.
